### PR TITLE
test: add unit tests for API endpoints

### DIFF
--- a/backend/test_api.py
+++ b/backend/test_api.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from backend.api import app # Importation de l'application FastAPI
+
+client = TestClient(app)
+
+class TestAPI(unittest.TestCase):
+    def test_health_endpoint(self):
+        """Teste si l'endpoint /health fonctionne correctement."""
+        response = client.get("/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "API is running"})
+    
+    @patch("backend.api.call_openai_api")
+    def test_query_endpoint(self, mock_openai):
+        """Teste l'endpoint /query avec un mock de call_openai_api."""
+        mock_openai.return_value = "Réponse simulée de l'IA"
+        response = client.post("/query", json={"query": "Quelle est la capitale de la France ?", "conversation_id": "test123"})
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"response": "Réponse simulée de l'IA"})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ajout de tests unitaires pour les endpoints de l'API FastAPI.
- Test de l'endpoint /health pour vérifier le bon fonctionnement de l'API.
- Test de l'endpoint /query avec un mock de call_openai_api pour éviter les appels réels à l'IA.
- Correction des imports et du format des requêtes pour assurer la compatibilité avec FastAPI. Les tests passent avec succès.